### PR TITLE
Add multithreading module with server

### DIFF
--- a/Multithreading/README.md
+++ b/Multithreading/README.md
@@ -6,3 +6,7 @@
 1. server.py         - A simple http server that takes in requests (from threadRequests.py) and responds with a random delay 0.2 <= delay <= 0.8 seconds.
 2. serialRequests.py - A client making requests to the http server on local host serially.
 3. threadRequests.py - A simple client making requests to the server using multiple threads.
+
+### E.g.
+### Run the server.py in the background
+#### python3.7 server.py &

--- a/Multithreading/README.md
+++ b/Multithreading/README.md
@@ -1,0 +1,8 @@
+# An application of the python Multi-threading module
+
+## This module demonstrates a use case for using multi-threading (as opposed to multi-processing) for I/O intensive operations.
+## The server responding with a random delay tries to emulate a (rather slow)
+
+1. server.py         - A simple http server that takes in requests (from threadRequests.py) and responds with a random delay 0.2 <= delay <= 0.8 seconds.
+2. serialRequests.py - A client making requests to the http server on local host serially.
+3. threadRequests.py - A simple client making requests to the server using multiple threads.

--- a/Multithreading/requirements.txt
+++ b/Multithreading/requirements.txt
@@ -1,0 +1,3 @@
+threading
+Queue
+http

--- a/Multithreading/serialRequests.py
+++ b/Multithreading/serialRequests.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import requests
+import time
+
+def make_http_requests(server_address, request_n):
+  """
+  A simple function to poll the http server in server.py
+  :server_address: (tuple) Input server address tuple of the form ('ip address', port)
+    ::'ip address':: (string) can be 'localhost' if server.py is running on the same machine
+    ::port:: (int) port at which server.py listens
+  :request_n: (int) an identifier, allows tracking each request with number
+  """
+  resp = requests.get("http://{0}:{1}".format(server_address[0], server_address[1]))
+  result_dict.append({request_n: "Status: {0}, Response: Server took {1}".format(resp.status_code, resp.text)})
+
+if __name__ == "__main__":
+
+  # Set total number of requests that will be made to the server
+  num_requests = 14
+
+  # Set the server address same as server.py module
+  server_address = ('localhost', 60998)
+
+  # Using a list to maintain order of request completion
+  result_dict = []
+
+  # Note start time
+  start_time = time.time()
+
+  # Making 20 requests serially
+  for _i in range(num_requests):
+    make_http_requests(server_address, _i+1)
+
+  print("Took {0} seconds to make {1} requests".format(str(time.time() - start_time), num_requests+1))
+  print(result_dict)

--- a/Multithreading/server.py
+++ b/Multithreading/server.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import http.server
+import time
+import random
+import threading
+
+class RandomDelayHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+
+  def do_GET(self):
+    self.send_response(200)
+    self.end_headers()
+    rand_float = random.uniform(0.2,0.8)
+    time.sleep(rand_float)
+    self.wfile.write("Took {0} seconds".format(str(rand_float)).encode(encoding='utf_8'))
+
+if __name__ == "__main__":
+
+  httpd = http.server.ThreadingHTTPServer(('localhost', 60998), RandomDelayHTTPRequestHandler)
+  #http_worker = threading.Thread(target=httpd.serve_forever, args=())
+  #http_worker.setDaemon(True)
+#  print("Server starting up")
+  #http_worker.start()
+#  print("Server started, sleeping for 10 secs..")
+#  time.sleep(15)
+  httpd.serve_forever()

--- a/Multithreading/threadRequests.py
+++ b/Multithreading/threadRequests.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import requests
+import time
+import threading
+import queue
+
+def make_http_requests(server_address, input_q, output_q):
+  """
+  A worker function that runs perpetually to, pick a request object from the input queue,
+   poll the http server in server.py, and write the result back to the output queue
+  :server_address: (tuple) Input server address tuple of the form ('ip address', port)
+    ::'ip address':: (string) can be 'localhost' if server.py is running on the same machine
+    ::port:: (int) port at which server.py listens
+  :input_q: (Queue) an input queue to pick request objects from
+  :output_q: (Queue) an output queue to write the result of the request into
+  """
+  while True:
+    request_n = input_q.get()
+    resp = requests.get("http://{0}:{1}".format(server_address[0], server_address[1]))
+    output_q.put({request_n: "Status: {0}, Response: Server took {1}".format(resp.status_code, resp.text)})
+    input_q.task_done()
+
+if __name__ == "__main__":
+
+  # Set total number of requests that will be made to the server
+  num_requests = 14
+
+  # Set number of threads/workers that will be spawned
+  threads = 10
+
+  # Set the server address same as server.py module
+  server_address = ('localhost', 60998)
+
+  # Declare input and output queues
+  input_queue = queue.Queue()
+  output_queue = queue.Queue()
+
+  # Note the start time
+  start_time = time.time()
+
+  # Spawn Daemon threads
+  for _i in range(threads):
+    worker = threading.Thread(target=make_http_requests, args=(server_address, input_queue, output_queue), daemon=True)
+    worker.start()
+
+  # Inject requests into the input queue
+  for _i in range(num_requests):
+    input_queue.put(_i+1)
+
+  # Wait for all worker threads to finish
+  input_queue.join()
+
+  print("Took {0} seconds to make {1} requests".format(str(time.time() - start_time), num_requests+1))
+  print(list(output_queue.queue))


### PR DESCRIPTION
This commit adds a use case for using multithreading for IO intensive operations. The server.py module runs a ThreadedHTTPSServer accepting requests from the serialRequests.py and threadRequests.py modules.